### PR TITLE
feat: enhance CV layout and PDF download

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,6 +31,7 @@
       --card: #ffffff;
     }
     html, body { height: 100%; }
+    html { scroll-behavior: smooth; }
     body {
       margin: 0; background: var(--bg); color: var(--muted);
       font-family: "Roboto", system-ui, -apple-system, Segoe UI, sans-serif;
@@ -52,7 +53,7 @@
       border: 1px solid var(--rule); background: #fff; border-radius: 8px; padding: 6px 12px; font-weight: 600;
       cursor: pointer; transition: transform .15s ease;
     }
-    .toolbar button.print { background: var(--accent); color: #fff; border-color: var(--accent); }
+    .toolbar button.download { background: var(--accent); color: #fff; border-color: var(--accent); }
     .toolbar button:hover { transform: scale(1.03); }
     @media (prefers-reduced-motion: reduce) { .toolbar button:hover { transform: none; } }
     .wrap { max-width: 960px; margin: 32px auto; padding: 0 16px; }
@@ -95,10 +96,15 @@
     .exp { border-left:2px solid var(--rule); padding-left:18px; }
     .exp-item { position:relative; margin:14px 0; line-height:1.45; break-inside:avoid; page-break-inside:avoid; }
     .exp-item::before{ content:""; position:absolute; left:-9px; top:6px; width:10px; height:10px; border-radius:50%; background:var(--accent); }
-    .exp-item h3 { margin:0; color:var(--ink); font-size:16px; }
-    .exp-item .meta{ display:block; color:#64748b; margin-top:2px; margin-left:0; }
+    .exp-item h3 { margin:0 0 4px; color:var(--ink); font-size:17px; font-weight:600; }
+    .exp-item .meta{ display:block; color:var(--accent); margin-top:0; margin-left:0; font-size:14px; }
     .exp-item ul { margin:8px 0 0 18px; }
     .exp-item li { margin:6px 0; }
+    .edu { border-left:2px solid var(--rule); padding-left:18px; }
+    .edu-item { position:relative; margin:14px 0; line-height:1.45; break-inside:avoid; page-break-inside:avoid; }
+    .edu-item::before{ content:""; position:absolute; left:-9px; top:6px; width:10px; height:10px; border-radius:50%; background:var(--accent-2); }
+    .edu-item h3 { margin:0 0 4px; color:var(--ink); font-size:16px; font-weight:600; }
+    .edu-item .meta{ display:block; color:#64748b; margin-top:0; font-size:14px; }
     .sidebar{ display:flex; flex-direction:column; }
     .projects{ margin-top:auto; }
     .projects ul{ margin:8px 0 0 18px; }
@@ -144,7 +150,7 @@
 <body>
   <a href="#main" class="skip-link">Skip to content</a>
   <div class="toolbar" role="navigation">
-    <button class="print" aria-label="Print" onclick="window.print()">Print</button>
+    <button class="download" id="download" aria-label="Download PDF">Download PDF</button>
     <button id="ats" aria-label="Toggle applicant tracking system friendly mode">ATS Mode</button>
   </div>
   <div class="wrap">
@@ -211,11 +217,17 @@
 
           <section class="section">
             <h2><i class="icon icons fa-solid fa-graduation-cap"></i>Education</h2>
-            <p><strong>Studies toward BSc — Software Engineering</strong></p>
-            <p>University of Engineering &amp; Technology (UET), Mardan · 2017 – 2021</p>
-            <p class="muted">Coursework completed; degree not yet conferred.</p>
-            <p><strong>FSc Pre‑Engineering</strong></p>
-            <p>Islamia College Peshawar · 2015 – 2017 · 82% (A grade)</p>
+            <div class="edu">
+              <div class="edu-item">
+                <h3>Studies toward BSc — Software Engineering</h3>
+                <div class="meta">University of Engineering &amp; Technology (UET), Mardan · 2017 – 2021</div>
+                <p class="muted">Coursework completed; degree not yet conferred.</p>
+              </div>
+              <div class="edu-item">
+                <h3>FSc Pre‑Engineering</h3>
+                <div class="meta">Islamia College Peshawar · 2015 – 2017 · 82% (A grade)</div>
+              </div>
+            </div>
           </section>
 
           <section class="section">
@@ -290,14 +302,25 @@
           </section>
         </aside>
       </div>
-      <footer class="footer" role="contentinfo">
+  <footer class="footer" role="contentinfo">
         Last updated: <span id="u"></span>
       </footer>
     </div>
   </div>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.10.1/html2pdf.bundle.min.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <script defer>
     document.getElementById('u').textContent = new Date().toLocaleDateString(undefined,{year:'numeric',month:'short',day:'2-digit'});
     document.getElementById('ats').addEventListener('click',function(){document.body.classList.toggle('ats');});
+    document.getElementById('download').addEventListener('click',function(){
+      const cv=document.querySelector('.card');
+      html2pdf().set({
+        margin:0,
+        filename:'Shafaat_Ali_CV.pdf',
+        image:{type:'jpeg',quality:0.98},
+        html2canvas:{scale:2,useCORS:true},
+        jsPDF:{unit:'in',format:'a4',orientation:'portrait'}
+      }).from(cv).save();
+    });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add Download PDF button powered by html2pdf and update toolbar styling
- highlight professional experience and education with timeline layout and improved meta styling
- tweak layout for smoother scrolling and improved UI polish

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7253b27a883278472568f2c648998