### PR TITLE
Simplify skills list styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,11 +88,8 @@
     .contact-list a:hover, .link-list a:hover { color: var(--accent); border-bottom-color: var(--accent); }
     .links a { overflow-wrap:anywhere; word-break:break-word; display:block; white-space:normal; }
     .links a.code { text-overflow:ellipsis; overflow:hidden; }
-    .skills { display: flex; flex-wrap: wrap; gap: 8px; list-style: none; margin: 0; padding: 0; }
-    .skills li { padding: 6px 12px; border-radius: 999px; background: linear-gradient(to bottom right, rgba(37,99,235,.08), rgba(20,184,166,.08));
-      border: 1px solid rgba(255,255,255,.6); box-shadow: inset 0 0 0 1px rgba(0,0,0,.05); font-weight: 600; transition: transform .15s ease; }
-    .skills li:hover { transform: scale(1.05); }
-    @media (prefers-reduced-motion: reduce) { .skills li:hover { transform: none; } }
+    .skills { margin: 8px 0 0 18px; padding: 0; }
+    .skills li { margin: 6px 0; }
     .exp { border-left:2px solid var(--rule); padding-left:18px; }
     .exp-item { position:relative; margin:14px 0; line-height:1.45; break-inside:avoid; page-break-inside:avoid; }
     .exp-item::before{ content:""; position:absolute; left:-9px; top:6px; width:10px; height:10px; border-radius:50%; background:var(--accent); }


### PR DESCRIPTION
## Summary
- Render core skills as a standard bulleted list instead of pill-style tags
- Drop gradient backgrounds and hover transforms from the skills list items

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7294119e88327a46393e3063835c8