### PR TITLE
refactor: improve Professional Summary readability

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,17 +58,15 @@
       </header>
       <div class="layout">
         <main id="main" role="main">
-          <section class="section summary">
-            <h2><i class="icon icons fa-solid fa-user"></i>Professional Summary</h2>
-            <div class="summary-wrap">
-              <div class="summary-icon decorative"><i class="fa-solid fa-user-tie"></i></div>
-              <div class="summary-text">
-                <p>
-                  <strong>Detail‑oriented Sales Coordinator</strong> with studies in <strong>Software Engineering (UET Mardan, 2017–2021)</strong> and proven success in sales support, online marketing, and client communication. Experienced in managing sales pipelines, coordinating with global clients, and using <strong>CRM tools (Apollo.io, HubSpot, Zoho)</strong>. Strong record of online ebook sales through <strong>Amazon, Etsy, Pinterest, and WhatsApp Business</strong>, plus content‑driven marketing on <strong>YouTube</strong>. Known for accurate reporting, timely follow‑ups, and smooth cross‑team coordination. I keep up with the latest developments in technology and leverage new tools to streamline sales and marketing processes and boost revenue. A lifelong learner, I quickly master new software, processes, and skills while bringing excellent communication and adaptability to every team.
-                </p>
+            <section class="section summary">
+              <h2><i class="icon icons fa-solid fa-user"></i>Professional Summary</h2>
+              <div class="summary-wrap">
+                <div class="summary-text">
+                  <p><strong>Detail‑oriented Sales Coordinator</strong> with studies in <strong>Software Engineering (UET Mardan, 2017–2021)</strong> and proven success in sales support, online marketing, and client communication. Experienced in managing sales pipelines, coordinating with global clients, and using <strong>CRM tools (Apollo.io, HubSpot, Zoho)</strong>. Strong record of online ebook sales through <strong>Amazon, Etsy, Pinterest, and WhatsApp Business</strong>, plus content‑driven marketing on <strong>YouTube</strong>.</p>
+                  <p>Known for accurate reporting, timely follow‑ups, and smooth cross‑team coordination. I keep up with the latest developments in technology and leverage new tools to streamline sales and marketing processes and boost revenue. A lifelong learner, I quickly master new software, processes, and skills while bringing excellent communication and adaptability to every team.</p>
+                </div>
               </div>
-            </div>
-          </section>
+            </section>
 
           <section class="section">
             <h2><i class="icon icons fa-solid fa-briefcase"></i>Professional Experience</h2>

--- a/style.css
+++ b/style.css
@@ -99,14 +99,23 @@ a { color: var(--accent); }
   .section h2 { display: flex; align-items: center; gap: 8px; color: var(--ink); font-size: 21px; margin: 0 0 12px; font-family: "Poppins", sans-serif; letter-spacing: .5px; border-bottom: 2px solid var(--accent); padding-bottom: 4px; }
   .section h2 .icon { font-size: 20px; color: var(--accent); }
 .summary { background: rgba(37,99,235,.05); }
-.summary-wrap { display: flex; flex-direction: column; gap: 16px; }
-.summary-icon { flex-shrink: 0; font-size: 48px; color: var(--accent); }
-.summary-text p { margin: 0; line-height: 1.6; }
-.summary-text p::first-line { font-size: 1.1em; font-weight: 500; color: var(--ink); }
-.summary strong { color: var(--accent); }
-@media (min-width: 900px) {
-  .summary-wrap { flex-direction: row; align-items: flex-start; }
-}
+  .summary-text p {
+    margin: 0 0 12px;
+    line-height: 1.6;
+  }
+  .summary-text p:last-child { margin-bottom: 0; }
+  .summary-text p::first-line {
+    font-size: 1.1em;
+    font-weight: 500;
+    color: var(--ink);
+  }
+  .summary strong { color: var(--accent); }
+  @media (min-width: 900px) {
+    .summary-text { column-count: 2; column-gap: 32px; }
+  }
+  @media print {
+    .summary-text { column-count: 1; }
+  }
 .contact-list, .link-list { list-style: none; margin: 0; padding: 0; }
 .contact-list li, .link-list li { margin: 4px 0; }
 .contact-list a, .link-list a { color: var(--muted); text-decoration: none; border-bottom: 1px solid transparent; }


### PR DESCRIPTION
## Summary
- remove decorative summary icon for a cleaner look
- split Professional Summary into two concise paragraphs with responsive two-column layout

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/Shafaat-CV/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68b736e466c08327984f8170781bfa23