### PR TITLE
Add dedicated print layout for PDF export

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@600;700;800&family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="print.css">
   <script type="application/ld+json" defer>
   {
     "@context": "https://schema.org",
@@ -245,13 +246,15 @@
     document.getElementById('ats').addEventListener('click',function(){document.body.classList.toggle('ats');});
     document.getElementById('download').addEventListener('click',function(){
       const cv=document.querySelector('.card');
+      document.body.classList.add('print');
       html2pdf().set({
         margin:0,
         filename:'Shafaat_Ali_CV.pdf',
         image:{type:'jpeg',quality:0.98},
         html2canvas:{scale:2,useCORS:true},
-        jsPDF:{unit:'in',format:'a4',orientation:'portrait'}
-      }).from(cv).save();
+        jsPDF:{unit:'in',format:'a4',orientation:'portrait'},
+        pagebreak:{mode:['avoid-all','css','legacy']}
+      }).from(cv).save().then(()=>document.body.classList.remove('print'));
     });
   </script>
 </body>

--- a/print.css
+++ b/print.css
@@ -1,0 +1,75 @@
+body.print {
+  --ink: #000;
+  --muted: #000;
+  --rule: #000;
+  --accent: #000;
+  --accent-2: #000;
+  --accent-3: #000;
+  --bg: #fff;
+  --card: #fff;
+  background: #fff;
+  color: #000;
+  font-size: 11pt;
+  line-height: 1.4;
+  font-family: "Roboto", system-ui, sans-serif;
+}
+body.print .toolbar,
+body.print .decorative,
+body.print .icons,
+body.print .header::before,
+body.print .skip-link { display: none !important; }
+body.print .card { box-shadow: none; border-radius: 0; }
+body.print a { color: #000; text-decoration: none; }
+body.print .layout { display: block; padding: 0; margin: 0; }
+body.print .section { break-inside: avoid; page-break-inside: avoid; margin-bottom: 16px; }
+body.print .exp { border-color: #000; }
+body.print .exp-item::before { background: #fff; border:2px solid #000; }
+body.print .edu { border-color: #000; }
+body.print .edu-item::before { background: #fff; border:2px solid #000; }
+body.print .edu-item .institution,
+body.print .edu-item .date,
+body.print .edu-item .note { color:#000; }
+body.print .skill-bar .bar span { background: #000; }
+body.print .skills li::before { background: #000; }
+body.print .summary { background: #fff; }
+body.print .summary strong { color: #000; }
+body.print h1,
+body.print h2 { page-break-after: avoid; }
+body.print .projects { break-inside: avoid; }
+body.print .summary-text { column-count: 1; }
+
+@media print {
+  body {
+    --ink: #000;
+    --muted: #000;
+    --rule: #000;
+    --accent: #000;
+    --accent-2: #000;
+    --accent-3: #000;
+    --bg: #fff;
+    --card: #fff;
+    background: #fff;
+    color: #000;
+    font-size: 11pt;
+    line-height: 1.4;
+    font-family: "Roboto", system-ui, sans-serif;
+  }
+  .toolbar, .decorative, .icons, .header::before, .skip-link { display: none !important; }
+  .card { box-shadow: none; border-radius: 0; }
+  a { color: #000; text-decoration: none; }
+  .layout { display: block; padding: 0; margin: 0; }
+  .section { break-inside: avoid; page-break-inside: avoid; margin-bottom: 16px; }
+  .exp { border-color: #000; }
+  .exp-item::before { background: #fff; border:2px solid #000; }
+  .edu { border-color: #000; }
+  .edu-item::before { background: #fff; border:2px solid #000; }
+  .edu-item .institution, .edu-item .date, .edu-item .note { color:#000; }
+  .skill-bar .bar span { background: #000; }
+  .skills li::before { background: #000; }
+  .summary { background: #fff; }
+  .summary strong { color: #000; }
+  h1, h2 { page-break-after: avoid; }
+  .projects { break-inside: avoid; }
+  .summary-text { column-count: 1; }
+  @page { size: A4; margin: 20mm; }
+}

--- a/style.css
+++ b/style.css
@@ -117,9 +117,6 @@ a { color: var(--accent); }
   @media (min-width: 900px) {
     .summary-text { column-count: 2; column-gap: 32px; }
   }
-  @media print {
-    .summary-text { column-count: 1; }
-  }
 .contact-list, .link-list { list-style: none; margin: 0; padding: 0; }
 .contact-list li, .link-list li { margin: 4px 0; }
 .contact-list a, .link-list a { color: var(--muted); text-decoration: none; border-bottom: 1px solid transparent; }
@@ -208,42 +205,6 @@ a { color: var(--accent); }
 .projects ul{ margin:8px 0 0 18px; }
 .projects li{ margin:6px 0; }
 .footer { padding: 16px 32px; color: #94a3b8; font-size: 12px; }
-@media print {
-  :root {
-    --ink: #000;
-    --muted: #000;
-    --rule: #000;
-    --accent: #000;
-    --accent-2: #000;
-    --accent-3: #000;
-    --bg: #fff;
-    --card: #fff;
-  }
-  body {
-    background: #fff;
-    color: #000;
-    font-size: 11pt;
-    line-height: 1.4;
-    font-family: "Roboto", system-ui, sans-serif;
-  }
-  .toolbar, .decorative, .icons, .header::before, .skip-link { display: none !important; }
-  .card { box-shadow: none; border-radius: 0; }
-  a { color: #000; text-decoration: none; }
-  .layout { display: block; padding: 0; margin: 0; }
-  .section { break-inside: avoid; page-break-inside: avoid; margin-bottom: 16px; }
-  .exp { border-color: #000; }
-  .exp-item::before { background: #fff; border:2px solid #000; }
-  .edu { border-color: #000; }
-  .edu-item::before { background: #fff; border:2px solid #000; }
-  .edu-item .institution, .edu-item .date, .edu-item .note { color:#000; }
-  .skill-bar .bar span { background: #000; }
-  .skills li::before { background: #000; }
-  .summary { background: #fff; }
-  .summary strong { color: #000; }
-  @page { size: A4; margin: 11mm; }
-  h1, h2 { page-break-after: avoid; }
-  .projects{ break-inside:avoid; }
-}
 body.ats { --accent: #000; --accent-2: #000; --accent-3: #000; --bg: #fff; --card: #fff; --rule: #000; color: #000; font-family: system-ui, sans-serif; }
 body.ats .card { box-shadow: none; }
 body.ats .header::before, body.ats .icon { display: none; }


### PR DESCRIPTION
## Summary
- Separate print styling into new `print.css` and load it alongside the main stylesheet
- Apply A4-friendly single-column formatting with clean margins and suppressed decorative elements
- Update PDF generation script to temporarily apply the print layout and avoid page-break issues

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/Shafaat-CV/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68b7452964548327af88dff52271dea5