### PR TITLE
Improve PDF layout and sidebar content

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,8 +65,8 @@
               <h2><i class="icon icons fa-solid fa-user"></i>Professional Summary</h2>
               <div class="summary-wrap">
                 <div class="summary-text">
-                  <p><strong>Detail‑oriented Sales Coordinator</strong> with studies in <strong>Software Engineering (UET Mardan, 2017–2021)</strong> and proven success in sales support, online marketing, and client communication. Experienced in managing sales pipelines, coordinating with global clients, and using <strong>CRM tools (Apollo.io, HubSpot, Zoho)</strong>. Strong record of online ebook sales through <strong>Amazon, Etsy, Pinterest, and WhatsApp Business</strong>, plus content‑driven marketing on <strong>YouTube</strong>.</p>
-                  <p>Known for accurate reporting, timely follow‑ups, and smooth cross‑team coordination. I keep up with the latest developments in technology and leverage new tools to streamline sales and marketing processes and boost revenue. A lifelong learner, I quickly master new software, processes, and skills while bringing excellent communication and adaptability to every team.</p>
+                  <p><strong>Detail‑oriented Sales Coordinator</strong> with studies in <strong>Software Engineering (UET Mardan, 2017–2021)</strong>. Proven success in sales support, online marketing, and client communication.</p>
+                  <p>Experienced in managing sales pipelines, coordinating with global clients, and using <strong>CRM tools (Apollo.io, HubSpot, Zoho)</strong>. Strong record of online ebook sales through <strong>Amazon, Etsy, Pinterest, and WhatsApp Business</strong>, plus content‑driven marketing on <strong>YouTube</strong>. Known for accurate reporting, timely follow‑ups, and smooth cross‑team coordination. A lifelong learner who quickly masters new software to streamline processes and boost revenue.</p>
                 </div>
               </div>
             </section>
@@ -118,16 +118,16 @@
               <div class="edu-item">
                 <div class="details">
                   <h3>Studies toward BSc — Software Engineering</h3>
-                  <div class="institution">University of Engineering &amp; Technology (UET), Mardan</div>
                   <div class="date">2017 – 2021</div>
+                  <div class="institution">University of Engineering &amp; Technology (UET), Mardan</div>
                   <p class="note muted">Coursework completed; degree not yet conferred.</p>
                 </div>
               </div>
               <div class="edu-item">
                 <div class="details">
                   <h3>FSc Pre‑Engineering</h3>
-                  <div class="institution">Islamia College Peshawar</div>
                   <div class="date">2015 – 2017</div>
+                  <div class="institution">Islamia College Peshawar</div>
                   <p class="note muted">82% (A grade)</p>
                 </div>
               </div>
@@ -207,6 +207,15 @@
             </ul>
           </section>
           <section class="section">
+            <h2><i class="icon icons fa-solid fa-wrench"></i>Tools &amp; Technologies</h2>
+            <ul class="skills">
+              <li>MS Excel &amp; Google Sheets</li>
+              <li>Canva &amp; basic video editors</li>
+              <li>HTML, CSS &amp; JavaScript</li>
+              <li>Git &amp; GitHub</li>
+            </ul>
+          </section>
+          <section class="section">
             <h2><i class="icon icons fa-solid fa-language"></i>Languages</h2>
             <ul class="skills">
               <li>English (Fluent)</li>
@@ -226,7 +235,7 @@
             </ul>
           </section>
           <section class="section projects"><h2>Current Projects</h2>
-            <ul>
+            <ul class="skills">
               <li>Becoming proficient in computer programming</li>
               <li>Creating software tools for sales departments</li>
               <li>Learning video editing, graphic design, and e-commerce</li>

--- a/print.css
+++ b/print.css
@@ -1,16 +1,16 @@
 body.print {
   --ink: #000;
   --muted: #000;
-  --rule: #000;
-  --accent: #000;
-  --accent-2: #000;
-  --accent-3: #000;
+  --rule: #cbd5e1;
+  --accent: #0d9488;
+  --accent-2: #0d9488;
+  --accent-3: #0d9488;
   --bg: #fff;
   --card: #fff;
   background: #fff;
   color: #000;
   font-size: 11pt;
-  line-height: 1.4;
+  line-height: 1.45;
   font-family: "Roboto", system-ui, sans-serif;
 }
 body.print .toolbar,
@@ -18,19 +18,31 @@ body.print .decorative,
 body.print .icons,
 body.print .header::before,
 body.print .skip-link { display: none !important; }
-body.print .card { box-shadow: none; border-radius: 0; }
+body.print .wrap { margin: 0; padding: 0; }
+body.print .card { box-shadow: none; border-radius: 0; border: none; }
 body.print a { color: #000; text-decoration: none; }
 body.print .layout { display: block; padding: 0; margin: 0; }
-body.print .section { break-inside: avoid; page-break-inside: avoid; margin-bottom: 16px; }
-body.print .exp { border-color: #000; }
-body.print .exp-item::before { background: #fff; border:2px solid #000; }
-body.print .edu { border-color: #000; }
-body.print .edu-item::before { background: #fff; border:2px solid #000; }
+body.print main,
+body.print aside { width: 100%; }
+body.print .section {
+  break-inside: avoid;
+  page-break-inside: avoid;
+  padding: 12px 0;
+  margin: 0;
+}
+body.print .section:not(:last-child) { border-bottom: 1px solid var(--rule); margin-bottom: 12px; }
+body.print .exp { border-color: var(--accent); }
+body.print .exp-item::before { background: #fff; border:2px solid var(--accent); }
+body.print .edu { border-color: var(--accent); }
+body.print .edu-item::before { background: #fff; border:2px solid var(--accent); }
 body.print .edu-item .institution,
 body.print .edu-item .date,
 body.print .edu-item .note { color:#000; }
-body.print .skill-bar .bar span { background: #000; }
-body.print .skills li::before { background: #000; }
+body.print .skill-bar .bar span { background: var(--accent); }
+body.print .skills li::before { background: var(--accent); }
+body.print .link-list li a { font-size: 10pt; }
+body.print ul { margin: 8px 0 0 20px; padding: 0; }
+body.print li { margin: 4px 0; }
 body.print .summary { background: #fff; }
 body.print .summary strong { color: #000; }
 body.print h1,
@@ -42,34 +54,46 @@ body.print .summary-text { column-count: 1; }
   body {
     --ink: #000;
     --muted: #000;
-    --rule: #000;
-    --accent: #000;
-    --accent-2: #000;
-    --accent-3: #000;
+    --rule: #cbd5e1;
+    --accent: #0d9488;
+    --accent-2: #0d9488;
+    --accent-3: #0d9488;
     --bg: #fff;
     --card: #fff;
     background: #fff;
     color: #000;
     font-size: 11pt;
-    line-height: 1.4;
+    line-height: 1.45;
     font-family: "Roboto", system-ui, sans-serif;
   }
   .toolbar, .decorative, .icons, .header::before, .skip-link { display: none !important; }
-  .card { box-shadow: none; border-radius: 0; }
+  .wrap { margin: 0; padding: 0; }
+  .card { box-shadow: none; border-radius: 0; border: none; }
   a { color: #000; text-decoration: none; }
   .layout { display: block; padding: 0; margin: 0; }
-  .section { break-inside: avoid; page-break-inside: avoid; margin-bottom: 16px; }
-  .exp { border-color: #000; }
-  .exp-item::before { background: #fff; border:2px solid #000; }
-  .edu { border-color: #000; }
-  .edu-item::before { background: #fff; border:2px solid #000; }
+  main,
+  aside { width: 100%; }
+  .section {
+    break-inside: avoid;
+    page-break-inside: avoid;
+    padding: 12px 0;
+    margin: 0;
+  }
+  .section:not(:last-child) { border-bottom: 1px solid var(--rule); margin-bottom: 12px; }
+  .exp { border-color: var(--accent); }
+  .exp-item::before { background: #fff; border:2px solid var(--accent); }
+  .edu { border-color: var(--accent); }
+  .edu-item::before { background: #fff; border:2px solid var(--accent); }
   .edu-item .institution, .edu-item .date, .edu-item .note { color:#000; }
-  .skill-bar .bar span { background: #000; }
-  .skills li::before { background: #000; }
+  .skill-bar .bar span { background: var(--accent); }
+  .skills li::before { background: var(--accent); }
+  .link-list li a { font-size: 10pt; }
+  ul { margin: 8px 0 0 20px; padding: 0; }
+  li { margin: 4px 0; }
   .summary { background: #fff; }
   .summary strong { color: #000; }
   h1, h2 { page-break-after: avoid; }
   .projects { break-inside: avoid; }
   .summary-text { column-count: 1; }
-  @page { size: A4; margin: 20mm; }
+  @page { size: A4; margin: 15mm; }
 }

--- a/style.css
+++ b/style.css
@@ -100,7 +100,7 @@ a { color: var(--accent); }
   .section { margin-bottom: 32px; background: var(--card); padding: 16px; border: 1px solid var(--rule); border-radius: 12px; transition: background .2s, box-shadow .2s; }
   .section:nth-of-type(even) { background: #f1f5f9; }
   .section:hover { box-shadow: 0 4px 12px rgba(15,23,42,.08); }
-  .section h2 { display: flex; align-items: center; gap: 8px; color: var(--ink); font-size: 21px; margin: 0 0 12px; font-family: "Poppins", sans-serif; letter-spacing: .5px; border-bottom: 2px solid var(--accent); padding-bottom: 4px; }
+  .section h2 { display: flex; align-items: center; gap: 8px; color: var(--ink); font-size: 21px; margin: 0 0 12px; font-family: "Poppins", sans-serif; font-weight: 700; letter-spacing: .5px; border-bottom: 2px solid var(--accent); padding-bottom: 4px; }
   .section h2 .icon { font-size: 20px; color: var(--accent); }
 .summary { background: rgba(37,99,235,.05); }
   .summary-text p {
@@ -121,6 +121,7 @@ a { color: var(--accent); }
 .contact-list li, .link-list li { margin: 4px 0; }
 .contact-list a, .link-list a { color: var(--muted); text-decoration: none; border-bottom: 1px solid transparent; }
 .contact-list a:hover, .link-list a:hover { color: var(--accent); border-bottom-color: var(--accent); }
+.link-list li a { font-size: 14px; }
 .links a { overflow-wrap:anywhere; word-break:break-word; display:block; white-space:normal; }
 .links a.code { text-overflow:ellipsis; overflow:hidden; }
 .skills {
@@ -143,14 +144,16 @@ a { color: var(--accent); }
   position: absolute;
   left: 0;
   top: 7px;
-  width: 8px;
-  height: 8px;
+  width: 6px;
+  height: 6px;
   border-radius: 50%;
   background: var(--accent);
 }
+.section ul:not(.skills) { margin:8px 0 0 20px; padding:0; }
+.section ul:not(.skills) li { margin:6px 0; }
 .exp { border-left:2px solid var(--rule); padding-left:28px; }
 .exp-item { position:relative; margin:24px 0; line-height:1.45; break-inside:avoid; page-break-inside:avoid; }
-.exp-item::before{ content:""; position:absolute; left:-34px; top:6px; width:12px; height:12px; border-radius:50%; background:var(--card); border:2px solid var(--accent); }
+.exp-item::before{ content:""; position:absolute; left:-30px; top:6px; width:10px; height:10px; border-radius:50%; background:var(--card); border:2px solid var(--accent); }
 .exp-header{ display:flex; justify-content:space-between; align-items:flex-start; flex-wrap:wrap; gap:8px; }
 .exp-item h3 { margin:0; color:var(--ink); font-size:17px; font-weight:600; font-family:"Poppins", sans-serif; }
 .exp-item .meta{ color:var(--muted); font-size:14px; font-weight:500; text-align:right; }
@@ -167,10 +170,10 @@ a { color: var(--accent); }
 .edu-item::before{
   content:"";
   position:absolute;
-  left:-34px;
+  left:-30px;
   top:6px;
-  width:12px;
-  height:12px;
+  width:10px;
+  height:10px;
   border-radius:50%;
   background:var(--card);
   border:2px solid var(--accent);
@@ -202,8 +205,6 @@ a { color: var(--accent); }
 }
 .sidebar{ display:flex; flex-direction:column; }
 .projects{ margin-top:auto; }
-.projects ul{ margin:8px 0 0 18px; }
-.projects li{ margin:6px 0; }
 .footer { padding: 16px 32px; color: #94a3b8; font-size: 12px; }
 body.ats { --accent: #000; --accent-2: #000; --accent-3: #000; --bg: #fff; --card: #fff; --rule: #000; color: #000; font-family: system-ui, sans-serif; }
 body.ats .card { box-shadow: none; }


### PR DESCRIPTION
## Summary
- Refine print stylesheet with teal accent, balanced A4 margins, single-column layout and consistent spacing
- Standardize bullet styling, reduce URL font size and shrink timeline markers for cleaner output
- Reorder education dates, add Tools & Technologies section and update Current Projects list formatting

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7473bea408327b0a09ad829d2c4c3