### PR TITLE
Enhance CV theming and readability

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="color-scheme" content="light dark" />
   <title>Shafaat Ali — Sales Coordinator CV</title>
   <meta name="description" content="Sales Coordinator CV for Shafaat Ali — online CV with print-to-PDF support." />
   <meta property="og:title" content="Shafaat Ali — Sales Coordinator CV" />

--- a/style.css
+++ b/style.css
@@ -9,14 +9,33 @@
   --bg-gradient: linear-gradient(135deg, #f8fafc 0%, #e2e8f0 100%);
   --card: #ffffff;
 }
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --ink: #f8fafc;
+    --muted: #cbd5e1;
+    --rule: #475569;
+    --accent: #38bdf8;
+    --accent-2: #0ea5e9;
+    --accent-3: #fbbf24;
+    --bg: #0f172a;
+    --bg-gradient: linear-gradient(135deg, #0f172a 0%, #1e293b 100%);
+    --card: #1e293b;
+  }
+}
 *, *::before, *::after { box-sizing: border-box; }
 html, body { height: 100%; }
 html { scroll-behavior: smooth; }
 body {
-  margin: 0; background: var(--bg-gradient, var(--bg)); color: var(--muted);
+  margin: 0;
+  background: var(--bg-gradient, var(--bg));
+  color: var(--muted);
   font-family: "Roboto", system-ui, -apple-system, Segoe UI, sans-serif;
-  font-size: 16px; line-height: 1.6;
-  -webkit-font-smoothing: antialiased; text-rendering: optimizeLegibility;
+  font-size: 16px;
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  transition: background 0.3s ease, color 0.3s ease;
 }
 a { color: var(--accent); }
 .skip-link {
@@ -35,6 +54,7 @@ a { color: var(--accent); }
 }
 .toolbar button.download { background: var(--accent); color: #fff; border-color: var(--accent); }
 .toolbar button:hover { transform: scale(1.03); }
+.toolbar button:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 @media (prefers-reduced-motion: reduce) { .toolbar button:hover { transform: none; } }
 .wrap { max-width: 1024px; margin: 32px auto; padding: 0 16px; }
 .card { background: var(--card); border-radius: 16px; box-shadow: 0 4px 20px rgba(15,23,42,.08); overflow: hidden; box-sizing: border-box; }
@@ -104,10 +124,14 @@ a { color: var(--accent); }
   .section h2 { display: flex; align-items: center; gap: 8px; color: var(--ink); font-size: 21px; margin: 0 0 12px; font-family: "Poppins", sans-serif; font-weight: 700; letter-spacing: .5px; border-bottom: 2px solid var(--accent); padding-bottom: 4px; }
   .section h2 .icon { font-size: 20px; color: var(--accent); }
 .summary { background: rgba(37,99,235,.05); }
-  .summary-text p {
-    margin: 0 0 12px;
-    line-height: 1.6;
-  }
+.summary-text {
+  max-width: 65ch;
+  margin: 0 auto;
+}
+.summary-text p {
+  margin: 0 0 12px;
+  line-height: 1.6;
+}
   .summary-text p:last-child { margin-bottom: 0; }
   .summary-text p::first-line {
     font-size: 1.1em;
@@ -116,7 +140,7 @@ a { color: var(--accent); }
   }
   .summary strong { color: var(--accent); }
   @media (min-width: 900px) {
-    .summary-text { column-count: 2; column-gap: 32px; }
+    .summary-text { column-count: 2; column-gap: 32px; max-width: none; margin: 0; }
   }
 .contact-list, .link-list { list-style: none; margin: 0; padding: 0; }
 .contact-list li, .link-list li { margin: 4px 0; }


### PR DESCRIPTION
## Summary
- support light/dark modes via `color-scheme` meta tag and CSS variables
- smooth theme transitions and improved focus styles for toolbar buttons
- wrap summary text for better readability on narrow screens

## Testing
- `npx --yes htmlhint index.html` *(fails: 403 Forbidden - GET https://registry.npmjs.org/htmlhint)*
- `npx --yes stylelint style.css` *(fails: 403 Forbidden - GET https://registry.npmjs.org/stylelint)*

------
https://chatgpt.com/codex/tasks/task_e_68b74b09a1c8832794a575bf80eb4fc2