### PR TITLE
Add one-page summary download option

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,6 +42,7 @@
   <a href="#main" class="skip-link">Skip to content</a>
   <div class="toolbar" role="navigation">
     <button class="download" id="download" aria-label="Download PDF">Download PDF</button>
+    <button class="download" id="download-summary" aria-label="Download one-page summary PDF">Download 1-Page PDF</button>
     <button id="ats" aria-label="Toggle applicant tracking system friendly mode">ATS Mode</button>
   </div>
   <div class="wrap">
@@ -237,13 +238,60 @@
       </footer>
     </div>
   </div>
+  <div id="summary-card" class="card" hidden>
+    <header class="header" role="banner">
+      <div class="id">
+        <h1>Shafaat Ali</h1>
+        <div class="role">Sales Coordinator</div>
+        <div class="role-secondary">Digital Marketing &amp; Sales Support</div>
+        <p class="tagline">Helping businesses grow through sales coordination, CRM tools, and digital marketing.</p>
+        <ul class="contact-list">
+          <li><i class="fa-solid fa-map-marker-alt icons"></i>Peshawar, Pakistan</li>
+          <li><i class="fab fa-whatsapp icons"></i>+92 346 9089446</li>
+          <li><i class="fa-solid fa-envelope icons"></i>shafaataliedu@gmail.com</li>
+        </ul>
+      </div>
+    </header>
+    <div class="layout">
+      <main>
+        <section class="section summary">
+          <h2><i class="icon icons fa-solid fa-user"></i>Professional Summary</h2>
+          <div class="summary-text">
+            <p><strong>Detail‑oriented Sales Coordinator</strong> with a background in software engineering. Skilled in CRM platforms, digital marketing, and cross‑team coordination.</p>
+          </div>
+        </section>
+        <section class="section">
+          <h2><i class="icon icons fa-solid fa-briefcase"></i>Experience</h2>
+          <ul class="skills">
+            <li>Founder &amp; Sales/Marketing Manager — Shafaat Ali Education (2024–Present)</li>
+            <li>Freelance Sales &amp; Digital Marketing Specialist (2019–Present)</li>
+            <li>Content Writer &amp; Virtual Assistant — Blueprint Digital (Feb 2022 – Sep 2022)</li>
+          </ul>
+        </section>
+        <section class="section">
+          <h2><i class="icon icons fa-solid fa-graduation-cap"></i>Education</h2>
+          <ul class="skills">
+            <li>Studies toward BSc Software Engineering — UET Mardan (2017–2021)</li>
+          </ul>
+        </section>
+        <section class="section">
+          <h2><i class="icon icons fa-solid fa-wrench"></i>Core Skills</h2>
+          <ul class="skills">
+            <li>Sales coordination &amp; CRM tools</li>
+            <li>Digital marketing &amp; content creation</li>
+            <li>Client communication &amp; reporting</li>
+          </ul>
+        </section>
+      </main>
+    </div>
+  </div>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.10.1/html2pdf.bundle.min.js" crossorigin="anonymous" referrerpolicy="no-referrer" defer></script>
   <script>
     window.addEventListener('DOMContentLoaded',function(){
       document.getElementById('u').textContent = new Date().toLocaleDateString(undefined,{year:'numeric',month:'short',day:'2-digit'});
       document.getElementById('ats').addEventListener('click',function(){document.body.classList.toggle('ats');});
       document.getElementById('download').addEventListener('click',function(){
-        const cv=document.querySelector('.card');
+        const cv=document.querySelector('.wrap .card');
         html2pdf().set({
           margin:0,
           filename:'Shafaat_Ali_CV.pdf',
@@ -252,6 +300,32 @@
           jsPDF:{unit:'in',format:'a4',orientation:'portrait'},
           pagebreak:{mode:['avoid-all','css','legacy']}
         }).from(cv).save();
+      });
+
+      const cvWrap=document.querySelector('.wrap');
+      const summary=document.getElementById('summary-card');
+      const summaryBtn=document.getElementById('download-summary');
+
+      summaryBtn.addEventListener('click',function(){
+        if(summary.hidden){
+          summary.hidden=false;
+          cvWrap.hidden=true;
+          html2pdf().set({
+            margin:0,
+            filename:'Shafaat_Ali_CV_One_Page.pdf',
+            image:{type:'jpeg',quality:0.98},
+            html2canvas:{scale:2,useCORS:true},
+            jsPDF:{unit:'in',format:'a4',orientation:'portrait'},
+            pagebreak:{mode:['avoid-all','css','legacy']}
+          }).from(summary).save();
+          this.textContent='Back to Full CV';
+          this.setAttribute('aria-label','Show full CV');
+        }else{
+          summary.hidden=true;
+          cvWrap.hidden=false;
+          this.textContent='Download 1-Page PDF';
+          this.setAttribute('aria-label','Download one-page summary PDF');
+        }
       });
     });
   </script>


### PR DESCRIPTION
## Summary
- show condensed 1-page CV when summary download button is pressed
- allow toggling between full CV and summary while generating PDF

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b75235ce488327a542c40a2e325406