### PR TITLE
Add toggleable one-page CV summary with PDF download

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
     <button class="download" id="download-summary" aria-label="Download one-page summary PDF">Download 1-Page PDF</button>
     <button id="ats" aria-label="Toggle applicant tracking system friendly mode">ATS Mode</button>
   </div>
-  <div class="wrap">
+  <div class="wrap" id="full">
     <div class="card">
       <header class="header" role="banner">
         <div class="id">
@@ -238,51 +238,53 @@
       </footer>
     </div>
   </div>
-  <div id="summary-card" class="card" style="position:absolute;left:-9999px;top:0;" hidden>
-    <header class="header" role="banner">
-      <div class="id">
-        <h1>Shafaat Ali</h1>
-        <div class="role">Sales Coordinator</div>
-        <div class="role-secondary">Digital Marketing &amp; Sales Support</div>
-        <p class="tagline">Helping businesses grow through sales coordination, CRM tools, and digital marketing.</p>
-        <ul class="contact-list">
-          <li><i class="fa-solid fa-map-marker-alt icons"></i>Peshawar, Pakistan</li>
-          <li><i class="fab fa-whatsapp icons"></i>+92 346 9089446</li>
-          <li><i class="fa-solid fa-envelope icons"></i>shafaataliedu@gmail.com</li>
-        </ul>
+  <div class="wrap" id="summary" hidden>
+    <div id="summary-card" class="card">
+      <header class="header" role="banner">
+        <div class="id">
+          <h1>Shafaat Ali</h1>
+          <div class="role">Sales Coordinator</div>
+          <div class="role-secondary">Digital Marketing &amp; Sales Support</div>
+          <p class="tagline">Helping businesses grow through sales coordination, CRM tools, and digital marketing.</p>
+          <ul class="contact-list">
+            <li><i class="fa-solid fa-map-marker-alt icons"></i>Peshawar, Pakistan</li>
+            <li><i class="fab fa-whatsapp icons"></i>+92 346 9089446</li>
+            <li><i class="fa-solid fa-envelope icons"></i>shafaataliedu@gmail.com</li>
+          </ul>
+        </div>
+      </header>
+      <div class="layout">
+        <main>
+          <section class="section summary">
+            <h2><i class="icon icons fa-solid fa-user"></i>Professional Summary</h2>
+            <div class="summary-text">
+              <p>Detail‑oriented Sales Coordinator with experience in sales support, online marketing and client communication.</p>
+            </div>
+          </section>
+          <section class="section">
+            <h2><i class="icon icons fa-solid fa-briefcase"></i>Experience</h2>
+            <ul class="skills">
+              <li>Founder &amp; Sales/Marketing Manager — Shafaat Ali Education (2024–Present)</li>
+              <li>Freelance Sales &amp; Digital Marketing Specialist (2019–Present)</li>
+              <li>Content Writer &amp; Virtual Assistant — Blueprint Digital (Feb 2022 – Sep 2022)</li>
+            </ul>
+          </section>
+          <section class="section">
+            <h2><i class="icon icons fa-solid fa-graduation-cap"></i>Education</h2>
+            <ul class="skills">
+              <li>Studies toward BSc Software Engineering — UET Mardan (2017–2021)</li>
+            </ul>
+          </section>
+          <section class="section">
+            <h2><i class="icon icons fa-solid fa-wrench"></i>Core Skills</h2>
+            <ul class="skills">
+              <li>Sales coordination &amp; CRM tools</li>
+              <li>Digital marketing &amp; content creation</li>
+              <li>Client communication &amp; reporting</li>
+            </ul>
+          </section>
+        </main>
       </div>
-    </header>
-    <div class="layout">
-      <main>
-        <section class="section summary">
-          <h2><i class="icon icons fa-solid fa-user"></i>Professional Summary</h2>
-          <div class="summary-text">
-            <p>Detail‑oriented Sales Coordinator with experience in sales support, online marketing and client communication.</p>
-          </div>
-        </section>
-        <section class="section">
-          <h2><i class="icon icons fa-solid fa-briefcase"></i>Experience</h2>
-          <ul class="skills">
-            <li>Founder &amp; Sales/Marketing Manager — Shafaat Ali Education (2024–Present)</li>
-            <li>Freelance Sales &amp; Digital Marketing Specialist (2019–Present)</li>
-            <li>Content Writer &amp; Virtual Assistant — Blueprint Digital (Feb 2022 – Sep 2022)</li>
-          </ul>
-        </section>
-        <section class="section">
-          <h2><i class="icon icons fa-solid fa-graduation-cap"></i>Education</h2>
-          <ul class="skills">
-            <li>Studies toward BSc Software Engineering — UET Mardan (2017–2021)</li>
-          </ul>
-        </section>
-        <section class="section">
-          <h2><i class="icon icons fa-solid fa-wrench"></i>Core Skills</h2>
-          <ul class="skills">
-            <li>Sales coordination &amp; CRM tools</li>
-            <li>Digital marketing &amp; content creation</li>
-            <li>Client communication &amp; reporting</li>
-          </ul>
-        </section>
-      </main>
     </div>
   </div>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.10.1/html2pdf.bundle.min.js" crossorigin="anonymous" referrerpolicy="no-referrer" defer></script>
@@ -291,7 +293,7 @@
       document.getElementById('u').textContent = new Date().toLocaleDateString(undefined,{year:'numeric',month:'short',day:'2-digit'});
       document.getElementById('ats').addEventListener('click',function(){document.body.classList.toggle('ats');});
       document.getElementById('download').addEventListener('click',function(){
-        const cv=document.querySelector('.wrap .card');
+        const cv=document.querySelector('#full .card');
         html2pdf().set({
           margin:0,
           filename:'Shafaat_Ali_CV.pdf',
@@ -302,16 +304,21 @@
         }).from(cv).save();
       });
       document.getElementById('download-summary').addEventListener('click',function(){
+        const full=document.getElementById('full');
+        const summaryWrap=document.getElementById('summary');
         const summary=document.getElementById('summary-card');
-        summary.hidden=false;
-        html2pdf().set({
-          margin:0,
-          filename:'Shafaat_Ali_CV_One_Page.pdf',
-          image:{type:'jpeg',quality:0.98},
-          html2canvas:{scale:2,useCORS:true},
-          jsPDF:{unit:'in',format:'a4',orientation:'portrait'},
-          pagebreak:{mode:['avoid-all','css','legacy']}
-        }).from(summary).save().then(()=>{summary.hidden=true;});
+        full.hidden=true;
+        summaryWrap.hidden=false;
+        setTimeout(function(){
+          html2pdf().set({
+            margin:0,
+            filename:'Shafaat_Ali_CV_One_Page.pdf',
+            image:{type:'jpeg',quality:0.98},
+            html2canvas:{scale:2,useCORS:true},
+            jsPDF:{unit:'in',format:'a4',orientation:'portrait'},
+            pagebreak:{mode:['avoid-all','css','legacy']}
+          }).from(summary).save().then(()=>{summaryWrap.hidden=true;full.hidden=false;});
+        },100);
       });
     });
   </script>


### PR DESCRIPTION
## Summary
- add a dedicated one-page summary card with contact details, condensed overview, key experience, education, and core skills
- update download logic to temporarily swap the main CV for the summary, enabling preview and one-page PDF generation

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b755c551d0832788131ef7b5522145