### PR TITLE
Condense one-page CV to fit A4

### DIFF
--- a/summary.html
+++ b/summary.html
@@ -45,9 +45,6 @@
 
     .skills{display:grid;grid-template-columns:1fr 1fr;gap:8px}
     .chip{background:#eef2ff;border:1px solid #dbeafe;border-radius:10px;padding:6px 10px;font-weight:600;font-size:13px;color:#1e3a8a}
-    .bars .bar{display:grid;grid-template-columns:120px 1fr;align-items:center;gap:10px}
-    .bars .track{height:7px;border-radius:999px;background:#e5e7eb;position:relative}
-    .bars .fill{position:absolute;inset:0;width:var(--w);background:linear-gradient(90deg,var(--accent),var(--accent2));border-radius:999px}
 
     .list ul{margin:0 0 0 18px}
     .list li{margin:4px 0}
@@ -86,10 +83,7 @@
           <a href="mailto:shafaataliedu@gmail.com">Email</a>
           <a href="tel:+923469089446">Phone</a>
           <a href="https://linkedin.com/in/shafaataliedu" target="_blank" rel="noopener">LinkedIn</a>
-          <a href="https://github.com/shafaataliedu" target="_blank" rel="noopener">GitHub</a>
           <a href="https://www.youtube.com/@shafaataliedu" target="_blank" rel="noopener">YouTube</a>
-          <a href="https://www.pinterest.com/shafaataliedu" target="_blank" rel="noopener">Pinterest</a>
-          <a href="https://www.upwork.com/freelancers/~01ad976f823982348c" target="_blank" rel="noopener">Upwork</a>
         </div>
       </div>
       <div class="grid">
@@ -108,18 +102,11 @@
           <div class="rule"></div>
           <div class="skills">
             <div class="chip">Sales Coordination</div>
-            <div class="chip">Client Management</div>
-            <div class="chip">CRM (Apollo/HubSpot/Zoho)</div>
-            <div class="chip">Lead Tracking</div>
+            <div class="chip">CRM Tools</div>
             <div class="chip">YouTube Marketing</div>
             <div class="chip">Amazon/Etsy/Pinterest</div>
           </div>
-          <div class="rule" style="margin-top:10px"></div>
-          <div class="bars" aria-label="Skill proficiency">
-            <div class="bar"><strong>Sales Ops</strong><div class="track"><span class="fill" style="--w:88%"></span></div></div>
-            <div class="bar"><strong>Digital Marketing</strong><div class="track"><span class="fill" style="--w:80%"></span></div></div>
-            <div class="bar"><strong>Communication</strong><div class="track"><span class="fill" style="--w:92%"></span></div></div>
-          </div>
+
         </div>
       </div>
     </header>
@@ -132,24 +119,21 @@
           <div class="ttl">Founder &amp; Sales/Marketing Manager — @shafaataliedu</div>
           <div class="meta">Jan 2024 – Present · Remote</div>
           <ul>
-            <li>Ran online sales & content schedules; handled CRM pipelines and reports.</li>
-            <li>Expanded brand via Pinterest/SEO, 4,000+ Shorts & 1,000+ ebooks.</li>
+            <li>Managed online sales, content schedules & CRM; grew brand via Pinterest/SEO with 4K Shorts & 1K ebooks.</li>
           </ul>
         </div>
         <div class="item">
           <div class="ttl">Freelance Sales &amp; Digital Marketing Specialist</div>
           <div class="meta">2019 – Present</div>
           <ul>
-            <li>Managed Amazon/Etsy/Pinterest/WhatsApp funnels; optimized listings & follow-ups.</li>
-            <li>Built dashboards, kept client records, and drove <b>150%+</b> sales gains.</li>
+            <li>Optimized Amazon/Etsy/Pinterest/WhatsApp funnels & dashboards, driving <b>150%+</b> sales gains.</li>
           </ul>
         </div>
         <div class="item">
           <div class="ttl">Content Writer &amp; Virtual Assistant — Blueprint Digital</div>
           <div class="meta">Feb 2022 – Sep 2022</div>
           <ul>
-            <li>Handled client communication, scheduling & coordination.</li>
-            <li>Created SEO content and sales documentation.</li>
+            <li>Coordinated clients and schedules; produced SEO content & sales docs.</li>
           </ul>
         </div>
       </section>
@@ -158,23 +142,15 @@
         <h2>Education &amp; Extras</h2>
         <div class="rule"></div>
         <ul style="margin-bottom:8px">
-          <li><b>Studies toward BSc — Software Engineering</b> · UET Mardan (2017–2021)<br><small>Coursework completed; degree not yet conferred.</small></li>
-          <li><b>FSc Pre‑Engineering</b> · Islamia College Peshawar (2015–2017) · 82% (A)</li>
+          <li><b>BSc Software Engineering (studies)</b> · UET Mardan, 2017–2021</li>
+          <li><b>FSc Pre‑Engineering</b> · Islamia College Peshawar, 2015–2017 · 82% (A)</li>
         </ul>
         <div class="rule"></div>
         <h2 style="margin-top:6px">Soft Skills</h2>
         <ul>
-          <li>Communication &amp; Client Handling</li>
-          <li>Time Management &amp; Organization</li>
+          <li>Communication</li>
+          <li>Time Management</li>
           <li>Team Collaboration &amp; Adaptability</li>
-        </ul>
-        <div class="rule"></div>
-        <h2 style="margin-top:6px">Links</h2>
-        <ul>
-          <li><a href="https://linkedin.com/in/shafaataliedu" target="_blank" rel="noopener">linkedin.com/in/shafaataliedu</a></li>
-          <li><a href="https://www.youtube.com/@shafaataliedu" target="_blank" rel="noopener">youtube.com/@shafaataliedu</a></li>
-          <li><a href="https://www.pinterest.com/shafaataliedu" target="_blank" rel="noopener">pinterest.com/shafaataliedu</a></li>
-          <li><a href="https://www.upwork.com/freelancers/~01ad976f823982348c" target="_blank" rel="noopener">Upwork profile</a></li>
         </ul>
       </aside>
     </div>


### PR DESCRIPTION
## Summary
- streamline one-page CV by trimming contact links and removing skill bars for a tighter layout
- condense experience and education sections to keep content within a single A4 page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b75d61b6dc8327abf19b398f53ce45